### PR TITLE
Add support for manifest variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ If the push failed, the failed app will be stopped and renamed with the **-faile
 - **manifest** : _required_ manifest of the app to push. The _path_ element inside the manifest will be ignored. The manifest must have only **one** application and it must be present under the `applications` key. The manifest can also be specified **inline**, see [bellow for an example](#inline-manifest).
 - **path** : _required (except for docker images)_ path for the app bits to deploy. a Glob can be specified, but it must resolve to only one path. If multiple paths match the blob, the deploy will fail (before any interaction with CF)
 - **environment_variables** : _optional_ a set of environment variable to set in the manifest file before pushing the app. They will take precedence over any environment variables present.
+- **vars** : _optional_ a set of variables to do substitutions with in the manifest file before pushing the app. **NOTE:** Cannot do variable substitution in application names!
+- **vars_files** : _optional_ a set of variable files to do substitutions with in the manifest file before pushing the app. **NOTE:** Cannot do variable substitution in application names!
 - **docker_username** : _optional_ used to authenticate to private docker registry when pushing docker image.
 - **docker_password** : _optional_ used to authenticate to private docker registry when pushing docker image.
 

--- a/out.js
+++ b/out.js
@@ -91,6 +91,12 @@ async function cmd() {
 
     fs.writeFileSync("manifest.yml", yaml.safeDump(manifest))
 
+    const vars_files = request.params.vars_files || []
+    if (request.params.vars) {
+      fs.writeFileSync("vars.yml", yaml.safeDump(request.params.vars))
+      vars_files.push("vars.yml")
+    }
+
     cf.auth(request.source)
     cf.target(request.source)
 
@@ -102,6 +108,7 @@ async function cmd() {
           name: request.params.name,
           path: path,
           manifest: "manifest.yml",
+          vars_files: vars_files,
           docker_password: request.params.docker_password,
           noStart: true
         })
@@ -115,6 +122,7 @@ async function cmd() {
           name: request.params.name,
           path: path,
           manifest: "manifest.yml",
+          vars_files: vars_files,
           docker_password: request.params.docker_password
         })
       }
@@ -130,6 +138,10 @@ async function cmd() {
       cf.rename({ from: venerable, to: request.params.name })
       console.log("Revert successful!")
       process.exit(1)
+    } finally {
+      if (request.params.vars) {
+        fs.unlinkSync("vars.yml")
+      }
     }
 
     const appInfo = cf.appInfo(request.params)

--- a/tests/test-out-with-vars-and-vars-files.sh
+++ b/tests/test-out-with-vars-and-vars-files.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEMP_DIR="$(mktemp -d -p "$DIR")"
+RAND="$(< /dev/urandom tr -dc 'a-zA-Z0-9' | head -c 32)"
+
+if [[ -z "$TEMP_DIR" || ! -d "$TEMP_DIR" ]]; then
+  echo "Failed to create temporary directory"
+  exit 1
+fi
+
+function cleanup {
+  rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+echo "test: should start app with inline manifest, substituting variables from files"
+
+cat <<EOF > $TEMP_DIR/vars-file-1.yml
+---
+value: incorrect
+file_1_var: file_1_val
+EOF
+
+cat <<EOF > $TEMP_DIR/vars-file-2.yml
+---
+value: still_incorrect
+file_2_var: file_2_val
+EOF
+
+# this function allows us to see the stderr output in red. Make it easy to see if 
+color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
+
+cat <<JSON | color ${DIR}/../out.js ${DIR}
+{
+  "source": {
+    "api": "",
+    "username": "",
+    "password": "",
+    "organization": null,
+    "space": null
+  },
+  "params": {
+    "name": "cf-zero-downtime-test",
+    "path": "app",
+    "manifest": {
+      "applications": [
+        {
+          "name": "cf-zero-downtime-test",
+          "buildpack": "nodejs_buildpack",
+          "memory": "64M",
+          "health-check-type": "http",
+          "health-check-http-endpoint": "/good"
+        }
+      ]
+    },
+    "environment_variables": {
+      "random_value": "((value))",
+      "file_1_var": "((file_1_var))",
+      "file_2_var": "((file_2_var))",
+      "inline_var": "((inline_var))"
+    },
+    "vars_files": [
+      "$TEMP_DIR/vars-file-1.yml",
+      "$TEMP_DIR/vars-file-2.yml"
+    ],
+    "vars": {
+      "value": "$RAND",
+      "inline_var": "inline_val"
+    }
+  }
+}
+JSON
+
+test "$(cf app cf-zero-downtime-test | awk '/^instances:/{print $2}')" == "1/1"
+
+env="$(cf env cf-zero-downtime-test)"
+test "$(awk '/^random_value:/ { print $2 }' <<< "$env")" == "$RAND"
+test "$(awk '/^file_1_var:/ { print $2 }' <<< "$env")" == "file_1_val"
+test "$(awk '/^file_2_var:/ { print $2 }' <<< "$env")" == "file_2_val"
+test "$(awk '/^inline_var:/ { print $2 }' <<< "$env")" == "inline_val"

--- a/tests/test-out-with-vars-files.sh
+++ b/tests/test-out-with-vars-files.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEMP_DIR="$(mktemp -d -p "$DIR")"
+RAND="$(< /dev/urandom tr -dc 'a-zA-Z0-9' | head -c 32)"
+
+if [[ -z "$TEMP_DIR" || ! -d "$TEMP_DIR" ]]; then
+  echo "Failed to create temporary directory"
+  exit 1
+fi
+
+function cleanup {
+  rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+echo "test: should start app with inline manifest, substituting variables from files"
+
+cat <<EOF > $TEMP_DIR/vars-file-1.yml
+---
+value: incorrect
+file_1_var: file_1_val
+EOF
+
+cat <<EOF > $TEMP_DIR/vars-file-2.yml
+---
+value: $RAND
+file_2_var: file_2_val
+EOF
+
+# this function allows us to see the stderr output in red. Make it easy to see if 
+color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
+
+cat <<JSON | color ${DIR}/../out.js ${DIR}
+{
+  "source": {
+    "api": "",
+    "username": "",
+    "password": "",
+    "organization": null,
+    "space": null
+  },
+  "params": {
+    "name": "cf-zero-downtime-test",
+    "path": "app",
+    "manifest": {
+      "applications": [
+        {
+          "name": "cf-zero-downtime-test",
+          "buildpack": "nodejs_buildpack",
+          "memory": "64M",
+          "health-check-type": "http",
+          "health-check-http-endpoint": "/good"
+        }
+      ]
+    },
+    "environment_variables": {
+      "random_value": "((value))",
+      "file_1_var": "((file_1_var))",
+      "file_2_var": "((file_2_var))"
+    },
+    "vars_files": [
+      "$TEMP_DIR/vars-file-1.yml",
+      "$TEMP_DIR/vars-file-2.yml"
+    ]
+  }
+}
+JSON
+
+test "$(cf app cf-zero-downtime-test | awk '/^instances:/{print $2}')" == "1/1"
+
+env="$(cf env cf-zero-downtime-test)"
+test "$(awk '/^random_value:/ { print $2 }' <<< "$env")" == "$RAND"
+test "$(awk '/^file_1_var:/ { print $2 }' <<< "$env")" == "file_1_val"
+test "$(awk '/^file_2_var:/ { print $2 }' <<< "$env")" == "file_2_val"

--- a/tests/test-out-with-vars.sh
+++ b/tests/test-out-with-vars.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+RAND="$(< /dev/random tr -dc 'a-zA-Z0-9' | head -c 32)"
+
+echo "test: should start app with inline manifest, substituting variables"
+
+# this function allows us to see the stderr output in red. Make it easy to see if 
+color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
+
+cat <<JSON | color ${DIR}/../out.js ${DIR}
+{
+  "source": {
+    "api": "",
+    "username": "",
+    "password": "",
+    "organization": null,
+    "space": null
+  },
+  "params": {
+    "name": "cf-zero-downtime-test",
+    "path": "app",
+    "manifest": {
+      "applications": [
+        {
+          "name": "cf-zero-downtime-test",
+          "buildpack": "nodejs_buildpack",
+          "memory": "64M",
+          "health-check-type": "http",
+          "health-check-http-endpoint": "/good"
+        }
+      ]
+    },
+    "environment_variables": {
+      "random_value": "((value))"
+    },
+    "vars": {
+      "value": "$RAND"
+    }
+  }
+}
+JSON
+
+test "$(cf app cf-zero-downtime-test | awk '/^instances:/{print $2}')" == "1/1"
+test "$(cf env cf-zero-downtime-test | awk '/^random_value:/ { print $2 }')" == "$RAND"


### PR DESCRIPTION
Adds two new parameters for `out`: `vars` and `vars_files`.
The `vars_files` are passed directly to the `cf push` command through the `--vars-file` argument.
The `vars` are dumped as yaml to the current working directory, and the file is appended to the array of `vars_files`.

Needed to bump CF CLI version to the current latest to support variable substitution.

This is a bit of a first pass, definitely would like feedback. It has already proved useful for me though.